### PR TITLE
[fixed] auto reconstruction of author name by clicking the input

### DIFF
--- a/classes/class.ilObjEtherpadLiteGUI.php
+++ b/classes/class.ilObjEtherpadLiteGUI.php
@@ -495,7 +495,7 @@ class ilObjEtherpadLiteGUI extends ilObjectPluginGUI
     	{
     		case stripos($type,'UDF') !== false:
     			$field_id = substr($type, strpos($type, ":")+1);
-    			return $this->getUDFValue($field_id) ? rawurlencode($this->getUDFValue($field_id)) : $this->txt("no_name_set"); break;			
+    			return $this->getUDFValue($field_id) ? rawurlencode($this->getUDFValue($field_id)) : $this->txt("unknown_identity"); break;			
     		case $type === 'username':
     			return rawurlencode($ilUser->getPublicName()); break;
     		case $type === 'fullname':

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -49,7 +49,8 @@ info_fullname#:#(z.B. Max Muster)
 username#:#Ilias-Nutzername
 info_username#:#(z.B. muster99)
 info_udf#:#Benutzerdefiniertes Textfeld.
-no_name_set#:#Fehlender Wert
+no_name_set#:#Kein Name gesetzt
+unknown_identity#:#Unbekannt
 at#:#unter
 
 show_chat#:#Chat anzeigen
@@ -124,7 +125,7 @@ info_conf_show_colors#:#Bei aktivierung, kann für jedes einzelne Etherpadobjekt
 author_identification_conf#:#Auswahl der Autorenbezeichnung in den Pad-Einstellungen
 info_author_identification_conf#:#Aktivierung ermöglicht in den Pad-Einstellungen eine Auswahl, wie Autoren darin benannt werden. (Feature seit 1.1.3) Bei Deaktivierung wird standardmäßig der Vor- und Nachname aus dem Profil angezeigt.
 
-author_identification_conf_author_identification_show_in_list#:#Autorenbezeichnungseinstellung in der Objektliste anzeigen
+author_identification_conf_author_identification_show_in_list#:#Ausgewählte Autorenbezeichnung in der Objektliste anzeigen
 info_author_identification_show_in_list#:#Die Autorenbezeichnungseinstellung in der Liste der Objekte anzeigen.
 
 author_identification_conf_author_identification_no_re-identification#:#Unterbinde Re-Identifizierung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -49,7 +49,8 @@ info_fullname#:#(e.g. John Q. Public)
 username#:#Ilias user name
 info_username#:#(e.g. public99)
 info_udf#:#user defined text field
-no_name_set#:#Missing value
+no_name_set#:#Missing Value
+unknown_identity#:#Unknown
 at#:#at
 
 show_chat#:#Show Chat

--- a/pad.js.sample
+++ b/pad.js.sample
@@ -50,7 +50,10 @@
     
 	$( "li[data-key='settings']" ).addClass("settings");
     
-	$( "#myusernameedit" ).prop('readonly', true);
+	// replace name input field
+	var span = $('<span />', {'id': 'myusernameedit'}).css({'display' : 'block'});
+	$("#myusernameedit").parent().append($(span).html(decodeURIComponent(parameters["userName"])));
+	$("#myusernameedit").remove();
 
 
 


### PR DESCRIPTION
The input field "myusernameedit" is'nt in use, because the author name
is fetched from users' profile. So it is set "readonly" in the custom
pad.js file. But by clicking the input the full name will be filled in
and replace the user defined field value, if chosen. This fix converts
the input into a span.

In addition a small translation improvement is provided.
